### PR TITLE
docs: add Contributors section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,9 @@ You can modify these in the `docker-compose.yml` file if needed.
 ├── requirements.txt    # Python dependencies
 └── README.md           # This documentation
 ```
+
+## Contributors
+
+- Elior Abaev
+- Adir Gelkop
+- Roee Levi   


### PR DESCRIPTION
This adds a new “Contributors” section at the end of the README listing:

## Contributors

- Elior Abaev
- Adir Gelkop
- Roee Levi  

No code changes, just documentation.

@eliorabaev @AdirGelkop could you please take a look? Thanks!